### PR TITLE
neverware: always enforce signature verification

### DIFF
--- a/grub-core/normal/main.c
+++ b/grub-core/normal/main.c
@@ -123,6 +123,17 @@ read_config_file (const char *config)
     }
 
   /* Try to open the config file.  */
+  /* Neverware: disable signature checking for this one file
+   * load. This is necessary because the config file is modified by
+   * postinst, so it won't have a valid signature. We prevent
+   * signature checking from being disabled in the config file, and
+   * also disable loading of new pubkeys from the config file, so an
+   * attacker cannot modify the config file to compromise signature
+   * checking.
+   *
+   * Signature checking is automatically re-enabled by grub_file_open
+   * after this one file is loaded. */
+  grub_file_filter_disable_pubkey ();
   rawfile = grub_file_open (config);
   if (! rawfile)
     return 0;


### PR DESCRIPTION
- The "check_signatures" variable no longer does anything, so
  signature checking can't be disabled from the config file or command
  line.

- The "trust" command has been removed, so additional signatures other
  than the ones built in with `grub-mkimage` cannot be added from the
  config file or command line.

- An exception to verification is added for the main grub
  configuration file. This file is edited by postinst, so it cannot be
  easily signed. The other changes in this commit should prevent the
  config file from being edited in a way that compromises secure boot.